### PR TITLE
chore(Dockerfile): Remove WORKFLOW_RELEASE env var

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -14,5 +14,3 @@ WORKDIR /var/lib/redis
 
 CMD ["/bin/boot"]
 EXPOSE 6379
-
-ENV WORKFLOW_RELEASE 2.1.0


### PR DESCRIPTION
This env var was recently removed for all other components. It was an oversight that it was included in this repo when initially created.
