### PR TITLE
feat(chart): added ability to configure persistence

### DIFF
--- a/charts/redis/templates/logger-redis-deployment.yaml
+++ b/charts/redis/templates/logger-redis-deployment.yaml
@@ -38,7 +38,16 @@ spec:
         volumeMounts:
         - name: logger-redis-creds
           mountPath: /var/run/secrets/deis/redis/creds
+        - name: logger-redis-data
+          mountPath: /var/lib/redis
       volumes:
+      - name: logger-redis-data
+      {{- if .Values.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: deis-logger-redis
+      {{- else }}
+        emptyDir: {}
+      {{- end }}
       - name: logger-redis-creds
         secret:
           secretName: logger-redis-creds

--- a/charts/redis/templates/logger-redis-pvc.yaml
+++ b/charts/redis/templates/logger-redis-pvc.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.persistence.enabled }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: deis-logger-redis
+  labels:
+    heritage: deis
+  annotations:
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass }}
+    component.deis.io/version: {{ .Values.docker_tag }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- end }}

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -17,3 +17,9 @@ db: "0"
 host: "redis host"
 port: "redis port"
 password: "redis password" # "" == no password
+
+persistence:
+  enabled: false
+  storageClass: standard
+  accessMode: ReadWriteOnce
+  size: 2Gi


### PR DESCRIPTION
In the future IMO Deis could use https://github.com/kubernetes/charts/tree/master/stable/redis but the problem is that chart requires to password-protect Redis which is unnecessary IMO.