### PR TITLE
feat(Makefile): set docker build flags via environment variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ branches:
 sudo: required
 services:
   - docker
+env:
+  - DOCKER_BUILD_FLAGS="--pull --no-cache"
 install:
   - make docker-build
 script:

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ dev:
 # For cases where we're building from local
 # We also alter the RC file to set the image name.
 docker-build:
-	docker build --no-cache --rm -t ${IMAGE} rootfs
+	docker build ${DOCKER_BUILD_FLAGS} -t ${IMAGE} rootfs
 	docker tag ${IMAGE} ${MUTABLE_IMAGE}
 
 test: test-style test-unit test-functional


### PR DESCRIPTION
Redis was already using `--no-cache`, so this just normalizes it with the env var approach used in other components.